### PR TITLE
BUG Removed the IPI field from the Uniprot loader.

### DIFF
--- a/waldo/uniprot/load.py
+++ b/waldo/uniprot/load.py
@@ -192,7 +192,6 @@ def _load_idmapping(datadir, session, organism_set):
             GI, \
             PDB, \
             GO, \
-            IPI, \
             UniRef100, \
             UniRef90, \
             UniRef50, \


### PR DESCRIPTION
According to the latest [Uniprot idmapping release](ftp://ftp.uniprot.org/pub/databases/uniprot/current_release/knowledgebase/idmapping/README), the `IPI` field has been removed. No other modifications to the specification have been made. Furthermore, this field did not appear to be used anywhere else in waldo, so this change is fairly straightforward. As I am not wholly familiar with the waldo architecture at this point, please correct me if this change is more substantive.

Addresses Issue #71.
